### PR TITLE
Add --enable-all and --disable-all rules

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,14 @@ func main() {
 					Usage: "disable rule",
 					Value: "",
 				},
+				cli.BoolFlag{
+					Name:  "enable-all",
+					Usage: "enable all rules",
+				},
+				cli.BoolFlag{
+					Name:  "disable-all",
+					Usage: "disable all rules",
+				},
 			},
 		},
 		{

--- a/main_rules.go
+++ b/main_rules.go
@@ -18,11 +18,29 @@ func GitSeekretRules(c *cli.Context) error {
 	enable := c.String("enable")
 	disable := c.String("disable")
 
-	if enable != "" {
+	enableAll := c.Bool("enable-all")
+	disableAll := c.Bool("disable-all")
+
+	if enableAll {
+		fmt.Println("Enabling all rules.")
+		gs.EnableRule(".*")
+	} else if disableAll {
+		fmt.Println("Disabling all rules.")
+		gs.DisableRule(".*")
+	}
+
+	// "all" represents that either enableAll or disableAll was triggered.
+	all := (enableAll || disableAll)
+
+	// If neither enableAll nor disableAll were used, let's look into doing
+	// individual enable and/or disable operations.
+	// Useful because in a single command you can specify both an --enable flag
+	// and a --disable flag but only want to do it if neither enable-all or disable-all were used.
+	if !all && enable != "" {
 		gs.EnableRule(enable)
 	}
 
-	if disable != "" {
+	if !all && disable != "" {
 		gs.DisableRule(disable)
 	}
 


### PR DESCRIPTION
In order to promote a better UX for users, instead of being a regex expert to enable all/disable all, there's a flag that can do it for the user.

cc @LinuxBozo @rogeruiz 

Closes  #12 

``` sh
$ ./git-seekret rules
List of rules:
        [ ] aws.secret_key
        [ ] aws.access_key
        [ ] newrelic.license_key
$ ./git-seekret rules --enable-all
Enabling all rules.
List of rules:
        [x] aws.secret_key
        [x] aws.access_key
        [x] newrelic.license_key
$ ./git-seekret rules --disable-all
Disabling all rules.
List of rules:
        [ ] aws.access_key
        [ ] aws.secret_key
        [ ] newrelic.license_key
```
