### PR TITLE
Add check to config init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,11 +73,12 @@ Usage
 Rules and Exceptions
 ====================
 
-The definition of rules and exceptions for ``git-seekret`` are defined by the seekret go library. A proper documentatio for this library can be found here;
+The definition of rules and exceptions for ``git-seekret`` are defined by the `seekret go library. Proper documentation for this library can be found here:
 
 	https://github.com/apuigsech/seekret
 
-
+Once you download the secrets, you will need to set your ``SEEKRET_RULES_PATH`` environment variable to point to the location of the rules.
+This is needed because by default, the ``seekret`` library will look for the rules in ``$GOPATH/src/github.com/apuigsech/seekret/rules``.
 
 
 Hands-On


### PR DESCRIPTION
Closes #8 and #9 

cc: @rogeruiz @LinuxBozo 

In order to improve the UX for the user when initializing the config, it would be great to explain and provide a possible remedy.

For many users, they will not have the source code of seekret so that default path will not work. Instead, we will detect if they are using the default path and suggest for them to use `SEEKRET_RULES_PATH`. And additionally, how to use it.

``` sh
$ ./git-seekret config --init
Unable to use default rulespath "/Users/jamesscott/Development/Workspaces/seekret-git-ws-fork/src/github.com/apuigsech/seekret/rules".
System Error: stat /Users/jamesscott/Development/Workspaces/seekret-git-ws-fork/src/github.com/apuigsech/seekret/rules: permission denied

HOW TO FIX:
Create your own rules folder and set the path of the folder to"SEEKRET_RULES_PATH" in your environment to override the default rules path.
Example command to create folder:
$ mkdir -p $HOME/.seekret_rules && export $SEEKRET_RULES_PATH=$HOME/.seekret_rules
Reinitialize your config afterwards.
```
