### PR TITLE
Fix options for check subcommand for staged files and commits

### DIFF
--- a/main_check.go
+++ b/main_check.go
@@ -16,17 +16,18 @@ func GitSeekretCheck(c *cli.Context) error {
 	}
 
 	options := map[string]interface{}{
-		"commit": false,
-		"staged": false,
+		"commit-files": false,
+		"staged-files": false,
 	}
 
 	if c.IsSet("commit") {
-		options["commit"] = true
-		options["commitcount"] = c.Int("commit")
+		options["commit-files"] = true
+		options["commit-messages"] = true
+		options["commit-count"] = c.Int("commit")
 	}
 
 	if c.IsSet("staged") {
-		options["staged"] = true
+		options["staged-files"] = true
 	}
 
 	secrets, err := gs.RunCheck(options)


### PR DESCRIPTION
Addresses #22 (the check subcommand not detecting secrets in staged files or commits)